### PR TITLE
Fix incorrect default in CLI

### DIFF
--- a/qp/cli.py
+++ b/qp/cli.py
@@ -88,7 +88,7 @@ def cli(i, o, modeller, protoss, coordination, skip):
         metals = click.prompt("> Active site metals", default="FE FE2").split(" ")
         limit = click.prompt("> Number of spheres", default=2)
         ligands = click.prompt(
-            "> Additional ligands [AAs and waters]", default=[], show_default=False
+            "> Additional ligands [AAs]", default=[], show_default=False
         )
         capping = int(
             click.prompt(


### PR DESCRIPTION
The default had been set to include waters in the cluster models. Given the substrates were not being included by default it makes sense to not include waters as well for the default. It should just be the metal and the proteogenic environment.