### PR TITLE
Update modeller to keep original number

### DIFF
--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -343,6 +343,7 @@ def compute_charge(spheres):
         "GLU": ["HE2", "HOE1"],
         "CYS": ["HG"],
         "TYR": ["HH"],
+        "OCS": []
     }
 
     charge = []

--- a/qp/structure/missing_loops.py
+++ b/qp/structure/missing_loops.py
@@ -40,6 +40,8 @@ Optimization level (``optimize`` argument in ``missing_loops.build_model``):
 import os
 from modeller import log, Environ, Selection
 from modeller.automodel import AutoModel
+from modeller import alignment, model
+
 
 
 log.none()
@@ -268,5 +270,17 @@ def build_model(residues, pdb, ali, out, optimize=1):
         a.make()
         for ext in ["ini", "rsr", "sch", "D00000001", "V99990001"]:
             os.remove(f"{pdb}_fill.{ext}")
+
+        # Transfer residue numbers and chain ids from reference model to the built model.
+        # Read the alignment for the transfer
+        aln = alignment(e, file=ali)
+
+        # Read the template and target models:
+        mdl_reference = model(e, file=pdb)  # Assuming 'pdb' is the reference pdb file
+        mdl_built = model(e, file=os.path.basename(out))
+
+        # Transfer the residue and chain ids and write out the modified MODEL:
+        mdl_built.res_num_from(mdl_reference, aln)
+        mdl_built.write(file=os.path.basename(out))
 
     os.chdir(cwd)


### PR DESCRIPTION
When Modeller ran, it would rewrite all the residue numbers starting at 1. This would lead to a lot of confusion later when we are trying to map the residues back to the literature. I used the built in model.res_num_from() function from Modeller to map the original numbering back to the Modeller structure.