### PR TITLE
Ignore missing terminal amino acids

### DIFF
--- a/qp/cli.py
+++ b/qp/cli.py
@@ -179,8 +179,8 @@ def cli(i, o, modeller, protoss, coordination, skip):
                 click.secho("Residue or atom limit exceeded\n", italic=True, fg="red")
                 err["Other"].append(pdb)
                 continue
-            except KeyError:
-                click.secho("Missing template atoms for capping\n", italic=True, fg="red")
+            except KeyError as e:
+                click.secho(f"Missing template atoms for capping {e}\n", italic=True, fg="red")
                 err["Coordination sphere"].append(pdb)
                 continue
 

--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -200,6 +200,7 @@ def construct_heavy(chain, parent, template, atom):
     res: Bio.PDB.Residue
         Residue containing added group
     """
+
     pos = {"CH3": template["CA"].get_coord()}
     if template.get_resname() == "GLY":
         pos["HH31"] = template["HA2"].get_coord()


### PR DESCRIPTION
I originally had the code adding in amino acids if they were missing at the terminal ends. This was not a good strategy has there are often very long stretches of amino acids at the ends of the protein that are missing. When they get added in with modeller they do not look realistic.