### PR TITLE
Strip chains for missing residues

### DIFF
--- a/qp/cli.py
+++ b/qp/cli.py
@@ -121,11 +121,11 @@ def run(i,
                 click.echo("> Building model")
                 AA = missing_loops.define_residues()
                 residues = missing_loops.get_residues(path, AA)
+                # Remove trailing missing residues from the ends of all chains
+                residues = missing_loops.clean_termini(residues)
+
                 ali_path = f"{o}/{pdb}/{pdb}.ali"
                 missing_loops.write_alignment(residues, pdb, path, ali_path)
-                
-                # Remove trailing missing residues from the ends of all chains
-                missing_loops.strip_alignment_file(ali_path)
                 missing_loops.build_model(residues, pdb, ali_path, mod_path, optimize)
 
         prot_path = f"{o}/{pdb}/Protoss"


### PR DESCRIPTION
Added a new function called `def clean_termini(residues)` that removes all the trailing residues from the `residues` variable. This method is superior to directly editing the alignment file which introduces other problems as both `residues` and the alignment file are used later on in the Modeller work flow.