### PR TITLE
Fix major reasons to charge errors during quantum chemistry jobs

### DIFF
--- a/qp/checks/charge_count.py
+++ b/qp/checks/charge_count.py
@@ -1,0 +1,39 @@
+import os
+from glob import glob
+from qp.manager.job_manager import get_charge
+
+
+ATOM_ELECTRON_MAP = {
+    "Fe": 26,
+    "H": 1,
+    "C": 6,
+    "N": 7,
+    "O": 8,
+    "S": 16,
+    "Cl": 17,
+    "Br": 35,
+    "P": 15,
+    "Se": 34,
+    "I": 53,
+    "F": 9
+}
+
+
+def count_electron(xyzfile):
+    with open(xyzfile) as f:
+        lines = f.readlines()[2:]
+    count = 0
+    for line in lines:
+        if line:
+            atom_type = line.split()[0].strip()
+            count += ATOM_ELECTRON_MAP[atom_type]
+    return count
+
+
+def check_charge(cluster_path):
+    charge = get_charge(cluster_path)
+    spinmult = 1
+    xyzfile = glob(os.path.join(cluster_path, "*.xyz"))[0]
+    num_electron = count_electron(xyzfile)
+    if (num_electron - charge) % 2 == spinmult % 2:
+        raise ValueError(f"charge {charge}, spin multiplicity {spinmult}, electron number {num_electron} in {cluster_path} are not consistent!")

--- a/qp/checks/charge_count.py
+++ b/qp/checks/charge_count.py
@@ -31,8 +31,8 @@ def count_electron(xyzfile):
 
 
 def check_charge(cluster_path):
-    charge = get_charge(cluster_path)
-    spinmult = 1
+    charge, extraspin = get_charge(cluster_path)
+    spinmult = 1 + extraspin
     xyzfile = glob(os.path.join(cluster_path, "*.xyz"))[0]
     num_electron = count_electron(xyzfile)
     if (num_electron - charge) % 2 == spinmult % 2:

--- a/qp/cli.py
+++ b/qp/cli.py
@@ -206,9 +206,15 @@ def run(i,
                     copy(path, old_path)
                 add_hydrogens.adjust_activesites(path, metals)
 
+            if charge:
+                ligand_charge = add_hydrogens.compute_charge(f"{prot_path}/{pdb}_ligands.sdf", path)
+            else:
+                ligand_charge = dict()
+
             clusters = coordination_spheres.extract_clusters(
                 path, f"{o}/{pdb}", metals,
-                limit, ligands, capping, charge, count, xyz, first_sphere_radius,
+                limit, ligands, capping, charge, count, xyz, first_sphere_radius, 
+                ligand_charge=ligand_charge,
                 smooth_method=smooth_method,
                 **smooth_params
             )
@@ -223,7 +229,6 @@ def run(i,
             #     continue
 
             if charge:
-                ligand_charge = add_hydrogens.compute_charge(f"{prot_path}/{pdb}_ligands.sdf", path)
                 with open(f"{o}/{pdb}/charge.csv", "a") as f:
                     f.write("\n")
                     for k, v in sorted(ligand_charge.items()):

--- a/qp/cli.py
+++ b/qp/cli.py
@@ -208,6 +208,7 @@ def run(i,
 
             if charge:
                 ligand_charge = add_hydrogens.compute_charge(f"{prot_path}/{pdb}_ligands.sdf", path)
+                ligand_spin = add_hydrogens.compute_spin(f"{prot_path}/{pdb}_ligands.sdf")
             else:
                 ligand_charge = dict()
 
@@ -232,6 +233,10 @@ def run(i,
                 with open(f"{o}/{pdb}/charge.csv", "a") as f:
                     f.write("\n")
                     for k, v in sorted(ligand_charge.items()):
+                        f.write(f"{k},{v}\n")
+                with open(f"{o}/{pdb}/spin.csv", "a") as f:
+                    f.write("\n")
+                    for k, v in sorted(ligand_spin.items()):
                         f.write(f"{k},{v}\n")
                 
                 from qp.checks.charge_count import check_charge

--- a/qp/cli.py
+++ b/qp/cli.py
@@ -87,7 +87,7 @@ def run(i,
         from qp.cluster import coordination_spheres
         click.echo("Coordination sphere parameters:")
         metals = click.prompt("> Active site metals", default="FE FE2").split(" ")
-        limit = click.prompt("> Number of spheres", default=3)
+        limit = click.prompt("> Number of spheres", default=2)
         first_sphere_radius = click.prompt("> Radius of first spheres", type=float, default=4.0)
         ligands = click.prompt("> Additional ligands [unnatural AAs] in outer coordination spheres", default=[], show_default=False)
         capping = int(
@@ -211,7 +211,7 @@ def run(i,
             else:
                 ligand_charge = dict()
 
-            clusters = coordination_spheres.extract_clusters(
+            cluster_paths = coordination_spheres.extract_clusters(
                 path, f"{o}/{pdb}", metals,
                 limit, ligands, capping, charge, count, xyz, first_sphere_radius, 
                 ligand_charge=ligand_charge,
@@ -233,6 +233,11 @@ def run(i,
                     f.write("\n")
                     for k, v in sorted(ligand_charge.items()):
                         f.write(f"{k},{v}\n")
+                
+                from qp.checks.charge_count import check_charge
+                for cluster_path in cluster_paths:
+                    check_charge(cluster_path)
+                        
 
         click.echo("")
 

--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -585,11 +585,11 @@ def compute_charge(spheres, structure, ligand_charge):
         "OCS": [],
         "CSD": ["HD1", "HD2"],
         "KCX": ["HQ1", "HQ2", "HOQ1", "HOQ2"],
-        "HIS": ["HD1"]
+        "HIS": ["HD1", "HE2"]
     }
 
     charge = []
-    for s in spheres[1:]:
+    for i, s in enumerate(spheres[1:]):
         c = 0
         for res in s:
             res_id = res.get_full_id()
@@ -598,19 +598,24 @@ def compute_charge(spheres, structure, ligand_charge):
             if ligand_key not in ligand_charge:
                 if resname in pos and all(res.has_id(h) for h in pos[resname]):
                     c += 1
+                    # print(res_id, resname, i+1, 1)
                 elif resname in neg and all(not res.has_id(h) for h in neg[resname]):
                     c -= 1
+                    # print(res_id, resname, i+1, -1)
                 if Polypeptide.is_aa(res) and resname != "PRO" and all(not res.has_id(h) for h in ["H", "H2"]):
                     # TODO: termini
                     c -= 1
+                    # print(res_id, resname, i+1, "B")
 
                 # Check for charged N-terminus
                 if res_id in n_terminals:
                     c += 1
+                    # print(res_id, resname, i+1, "N")
 
                 # Check for charged C-terminus
                 if res.has_id("OXT"):
                     c -= 1
+                    # print(res_id, resname, i+1, "C")
 
         charge.append(c)
     return charge
@@ -713,9 +718,9 @@ def extract_clusters(
                     sphere_path = f"{cluster_path}/{i}.pdb"
                     sphere_paths.append(sphere_path)
                     write_pdb(io, spheres[i], sphere_path)
-            if capping:
-                for cap in cap_residues:
-                    cap.get_parent().detach_child(cap.get_id())
+            # if capping:
+            #     for cap in cap_residues:
+            #         cap.get_parent().detach_child(cap.get_id())
             if xyz:
                 struct_to_file.to_xyz(f"{cluster_path}/{metal_id}.xyz", *sphere_paths)
                 struct_to_file.combine_pdbs(f"{cluster_path}/{metal_id}.pdb", metals, *sphere_paths)

--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -23,6 +23,7 @@ performed by specifying ``capping`` in ``coordination_spheres.extract_clusters``
 import os
 import numpy as np
 from Bio.PDB import PDBParser, Polypeptide, PDBIO, Select
+from Bio.PDB.PDBExceptions import PDBConstructionException
 from Bio.PDB.Atom import Atom
 from Bio.PDB.Residue import Residue
 from Bio.PDB.NeighborSearch import NeighborSearch
@@ -390,13 +391,16 @@ def build_hydrogen(chain, parent, template, atom):
     else:
         pos = scale_hydrogen(parent["C"], template["N"], 1.09 / 1.32)
 
-    res_id = ("H_" + parent.get_resname(), template.get_id()[1], " ")
+    res_id = parent.id
     if not chain.has_id(res_id):
         res = Residue(res_id, parent.get_resname(), " ")
         res.add(Atom("H1", pos, 0, 1, " ", "H1", None, "H"))
         chain.add(res)
     else:
-        chain[res_id].add(Atom("H2", pos, 0, 1, " ", "H2", None, "H"))
+        if "H1" in chain[res_id]:
+            chain[res_id].add(Atom("H2", pos, 0, 1, " ", "H2", None, "H"))
+        else:
+            chain[res_id].add(Atom("H1", pos, 0, 1, " ", "H1", None, "H"))
     return chain[res_id]
 
 
@@ -573,8 +577,8 @@ def compute_charge(spheres, structure):
         "MLZ": []
     }
     neg = {
-        "ASP": ["HD2"],
-        "GLU": ["HE2", "HOE1"],
+        "ASP": ["HD2", "HOD1", "HOD2"],
+        "GLU": ["HE2", "HOE1", "HOE2"],
         "CYS": ["HG"],
         "TYR": ["HH"],
         "OCS": [],
@@ -582,25 +586,30 @@ def compute_charge(spheres, structure):
     }
 
     charge = []
-    for s in spheres[1:]:
+    for si, s in enumerate(spheres[1:]):
         c = 0
         for res in s:
             res_id = res.get_full_id()
             resname = res.get_resname()
             if resname in pos and all(res.has_id(h) for h in pos[resname]):
                 c += 1
+                print(res_id, resname, si + 1, 1)
             elif resname in neg and all(not res.has_id(h) for h in neg[resname]):
                 c -= 1
+                print(res_id, resname, si + 1, -1)
             if Polypeptide.is_aa(res) and resname != "PRO" and all(not res.has_id(h) for h in ["H", "H2"]):
                 # TODO: termini
+                print(res_id, resname, si + 1)
                 c -= 1
 
             # Check for charged N-terminus
             if res_id in n_terminals:
+                print(res_id, resname, si + 1, "N")
                 c += 1
 
             # Check for charged C-terminus
             if res.has_id("OXT"):
+                print(res_id, resname, si + 1, "C")
                 c -= 1
 
         charge.append(c)
@@ -701,9 +710,9 @@ def extract_clusters(
                     sphere_path = f"{out}/{metal_id}/{i}.pdb"
                     sphere_paths.append(sphere_path)
                     write_pdb(io, spheres[i], sphere_path)
-            if capping:
-                for cap in cap_residues:
-                    cap.get_parent().detach_child(cap.get_id())
+            # if capping:
+            #     for cap in cap_residues:
+            #         cap.get_parent().detach_child(cap.get_id())
             if xyz:
                 struct_to_file.to_xyz(f"{out}/{metal_id}/{metal_id}.xyz", *sphere_paths)
                 struct_to_file.combine_pdbs(f"{out}/{metal_id}/{metal_id}.pdb", metals, *sphere_paths)

--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -586,30 +586,25 @@ def compute_charge(spheres, structure):
     }
 
     charge = []
-    for si, s in enumerate(spheres[1:]):
+    for s in spheres[1:]:
         c = 0
         for res in s:
             res_id = res.get_full_id()
             resname = res.get_resname()
             if resname in pos and all(res.has_id(h) for h in pos[resname]):
                 c += 1
-                print(res_id, resname, si + 1, 1)
             elif resname in neg and all(not res.has_id(h) for h in neg[resname]):
                 c -= 1
-                print(res_id, resname, si + 1, -1)
             if Polypeptide.is_aa(res) and resname != "PRO" and all(not res.has_id(h) for h in ["H", "H2"]):
                 # TODO: termini
-                print(res_id, resname, si + 1)
                 c -= 1
 
             # Check for charged N-terminus
             if res_id in n_terminals:
-                print(res_id, resname, si + 1, "N")
                 c += 1
 
             # Check for charged C-terminus
             if res.has_id("OXT"):
-                print(res_id, resname, si + 1, "C")
                 c -= 1
 
         charge.append(c)
@@ -710,9 +705,9 @@ def extract_clusters(
                     sphere_path = f"{out}/{metal_id}/{i}.pdb"
                     sphere_paths.append(sphere_path)
                     write_pdb(io, spheres[i], sphere_path)
-            # if capping:
-            #     for cap in cap_residues:
-            #         cap.get_parent().detach_child(cap.get_id())
+            if capping:
+                for cap in cap_residues:
+                    cap.get_parent().detach_child(cap.get_id())
             if xyz:
                 struct_to_file.to_xyz(f"{out}/{metal_id}/{metal_id}.xyz", *sphere_paths)
                 struct_to_file.combine_pdbs(f"{out}/{metal_id}/{metal_id}.pdb", metals, *sphere_paths)

--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -396,10 +396,13 @@ def build_hydrogen(chain, parent, template, atom):
         res.add(Atom("H1", pos, 0, 1, " ", "H1", None, "H"))
         chain.add(res)
     else:
-        if "H1" in chain[res_id]:
+        if "H1" not in chain[res_id]:
+            chain[res_id].add(Atom("H1", pos, 0, 1, " ", "H1", None, "H"))
+        elif "H2" not in chain[res_id]:
             chain[res_id].add(Atom("H2", pos, 0, 1, " ", "H2", None, "H"))
         else:
-            chain[res_id].add(Atom("H1", pos, 0, 1, " ", "H1", None, "H"))
+            chain[res_id].add(Atom("H3", pos, 0, 1, " ", "H3", None, "H"))
+            
     return chain[res_id]
 
 

--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -583,7 +583,9 @@ def compute_charge(spheres, structure, ligand_charge):
         "CYS": ["HG"],
         "TYR": ["HH"],
         "OCS": [],
-        "CSD": ["HD1", "HD2"]
+        "CSD": ["HD1", "HD2"],
+        "KCX": ["HQ1", "HQ2", "HOQ1", "HOQ2"],
+        "HIS": ["HD1"]
     }
 
     charge = []

--- a/qp/manager/job_manager.py
+++ b/qp/manager/job_manager.py
@@ -98,10 +98,10 @@ def get_charge(structure_dir=None):
     else:
         charge_dir = os.path.abspath(os.path.join(structure_dir, "../"))
     charge_csv_path = os.path.join(charge_dir, "charge.csv")
-    first_sphere_path = os.path.join(structure_dir, "1.pdb")
     
     charge = 0
     section = 1
+    num_sphere = 0
     chain_identifier = os.path.basename(structure_dir)
     chain = os.path.basename(structure_dir)[0]
 
@@ -117,6 +117,7 @@ def get_charge(structure_dir=None):
             # Parse charge.csv section 1
             if section == 1 and line.startswith(chain_identifier):
                 parts = line.split(',')
+                num_sphere = len(parts) - 1
                 current_chain_identifier = parts[0]
                 if current_chain_identifier == chain_identifier:
                     charge += sum([int(x) for x in parts[1:]])
@@ -124,8 +125,10 @@ def get_charge(structure_dir=None):
             # Parse charge.csv section 2
             elif section == 2 and '_' + chain in line:
                 ligand, value = line.split(',')
-                if residue_exists(first_sphere_path, ligand.split('_')[0]):
-                    charge += int(value)
+                for i in range(num_sphere):
+                    sphere_path = os.path.join(structure_dir, f"{i + 1}.pdb")
+                    if residue_exists(sphere_path, ligand.split('_')[0]):
+                        charge += int(value)
     
     return charge
 

--- a/qp/manager/job_manager.py
+++ b/qp/manager/job_manager.py
@@ -43,11 +43,12 @@ def find_heavy():
 
     return compress_sequence(non_hydrogens)
 
-def residue_exists(first_sphere_path, ligand_name):
+def residue_exists(sphere_path, res_name, chain, res_id):
     """Returns True if ligand_name exists in the pdb file."""
-    with open(first_sphere_path, 'r') as f:
+    with open(sphere_path, 'r') as f:
         for line in f:
-            if line.startswith("HETATM") and ligand_name in line:
+            if line.startswith("HETATM") and res_name == line[17:20].strip() \
+                and chain == line[21] and res_id == int(line[22:26]):
                 return True
     return False
 
@@ -123,11 +124,14 @@ def get_charge(structure_dir=None):
                     charge += sum([int(x) for x in parts[1:]])
 
             # Parse charge.csv section 2
-            elif section == 2 and '_' + chain in line:
+            elif section == 2:
                 ligand, value = line.split(',')
+                res_name, res_id_full = ligand.split('_')
+                chain = res_id_full[0]
+                res_id = int(res_id_full[1:])
                 for i in range(num_sphere):
                     sphere_path = os.path.join(structure_dir, f"{i + 1}.pdb")
-                    if residue_exists(sphere_path, ligand.split('_')[0]):
+                    if residue_exists(sphere_path, res_name, chain, res_id):
                         charge += int(value)
     
     return charge

--- a/qp/manager/job_manager.py
+++ b/qp/manager/job_manager.py
@@ -89,13 +89,14 @@ def get_electronic(pdb_id, master_list):
         sys.exit()
 
 
-def get_charge():
+def get_charge(structure_dir=None):
     """Extract the charge values from charge.csv"""
-    current_dir = os.getcwd()
-    
-    # Construct relative paths
-    charge_dir = os.path.abspath(os.path.join(current_dir, "../../"))
-    structure_dir = os.path.abspath(os.path.join(current_dir, "../"))
+    if structure_dir is None:
+        current_dir = os.getcwd()
+        charge_dir = os.path.abspath(os.path.join(current_dir, "../../"))
+        structure_dir = os.path.abspath(os.path.join(current_dir, "../"))
+    else:
+        charge_dir = os.path.abspath(os.path.join(structure_dir, "../"))
     charge_csv_path = os.path.join(charge_dir, "charge.csv")
     first_sphere_path = os.path.join(structure_dir, "1.pdb")
     

--- a/qp/structure/add_hydrogens.py
+++ b/qp/structure/add_hydrogens.py
@@ -353,3 +353,29 @@ def compute_charge(path_ligand, path_pdb):
                     cnt += 1
         charge[name] -= (n_atom - cnt)
     return charge
+
+
+def compute_spin(path_ligand):
+    with open(path_ligand, "r") as f:
+        sdf = f.read()
+
+    ligands = [
+        [t for t in s.splitlines() if t != ""]
+        for s in sdf.split("$$$$")
+        if s != "\n" and s != ""
+    ]
+    spin = {}
+    for l in ligands:
+        title = l[0].split("_")
+        name_id = [
+            (res_name, chain_id, res_id) 
+            for res_name, chain_id, res_id 
+            in zip(title[::3], title[1::3], title[2::3])
+        ]
+        name = " ".join([f"{res_name}_{chain_id}{res_id}" for res_name, chain_id, res_id in name_id])
+        for res_name, chain_id, res_id in name_id:
+            if res_name == "NO":
+                spin[name] = 1
+            elif res_name == "OXY":
+                spin[name] = 2
+    return spin


### PR DESCRIPTION
## Description
- Keep all the added H within the residue where it should be. Fix the feature that no added H is kept in the cluster PDB file.
- Accommodate the Protoss's atomic name convention of carboxylic acids in more amino acids.
- Fix the charge double-counting bug if a residue is an amino acid and a ligand at the same time.
- Detect the deprotonated state of HIS and assign a negative charge to it.
- Detect the ligands' charge in the spheres outside the first spheres or in another chain.
- Correctly count the ligands' charge when a part of ligands with the same name is outside the cluster.
- Consider the spin multiplicity contributed by the NO radical and triplet O2.
- Add a test function to examine if the charge, spin multiplicity and number of electrons are consistent after building the cluster.