### PR TITLE
Merge nearby cluster centers

### DIFF
--- a/qp/cli.py
+++ b/qp/cli.py
@@ -80,6 +80,7 @@ def run(config):
         smooth_method = smooth_method_options[smooth_choice]
 
         center_residues = config_data.get('center_residues', [])
+        merge_cutoff = config_data.get('merge_distance_cutoff', 4.0)
         charge = config_data.get('compute_charges', True)
         count = config_data.get('count_residues', True)
         xyz = config_data.get('write_xyz', True)
@@ -143,8 +144,8 @@ def run(config):
                 import qp
                 pdbl = pdb.lower()
                 prepared_flag = False
-                for path in qp.__path__:
-                    prepared_prot_path = os.path.join(path, f"prepared/{pdbl}/Protoss")
+                for qp_path in qp.__path__:
+                    prepared_prot_path = os.path.join(qp_path, f"prepared/{pdbl}/Protoss")
                     if os.path.exists(prepared_prot_path):
                         prepared_flag = True
                 if prepared_flag:
@@ -170,6 +171,7 @@ def run(config):
                     add_hydrogens.download(job, f"{prot_path}/{pdb}_protoss.pdb", "protein")
                     add_hydrogens.download(job, f"{prot_path}/{pdb}_ligands.sdf", "ligands")
                     add_hydrogens.download(job, f"{prot_path}/{pdb}_log.txt", "log")
+                    add_hydrogens.repair_ligands(f"{prot_path}/{pdb}_protoss.pdb", path)
 
         if coordination:
             click.echo("> Extracting clusters")
@@ -193,8 +195,8 @@ def run(config):
                 ligand_charge = dict()
 
             cluster_paths = coordination_spheres.extract_clusters(
-                path, f"{output}/{pdb}", center_residues,
-                limit, ligands, capping, charge, count, xyz, first_sphere_radius, 
+                path, f"{output}/{pdb}", center_residues, limit, 
+                merge_cutoff, ligands, capping, charge, count, xyz, first_sphere_radius, 
                 ligand_charge=ligand_charge,
                 smooth_method=smooth_method, hetero_pdb=hetero_pdb,
                 **smooth_params

--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -214,10 +214,6 @@ def get_center_residues(model, center_residues, merge_cutoff=4.0):
     for res in found:
         if res not in seen:
             centers.append(merge_centers(res, search, seen, merge_cutoff))
-    for c in centers:
-        for r in c:
-            print(r.get_full_id())
-        print()
     return centers
 
 

--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -188,6 +188,8 @@ def merge_centers(cur, search, seen, radius=4.0):
     seen.add(cur)
     nxt = set()
     for atom in cur.get_unpacked_list():
+        if atom.element == "H":
+            continue
         for res in search.search(atom.get_coord(), radius, "R"):
             nxt.add(res)
     for res in nxt:
@@ -202,7 +204,7 @@ def get_center_residues(model, center_residues, merge_cutoff=4.0):
     for res in model.get_residues():
         if res.get_resname() in center_residues:
             found.add(res)
-            center_atoms.extend(res.get_unpacked_list())
+            center_atoms.extend([atom for atom in res.get_unpacked_list() if atom.element != "H"])
     if not len(center_atoms):
         raise ValueError("No matching cluster centers found")
     

--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -183,6 +183,42 @@ def voronoi(model, center_residues, ligands, smooth_method, **smooth_params):
     return neighbors
 
 
+def merge_centers(cur, search, seen, radius=4.0):
+    center = {cur}
+    seen.add(cur)
+    nxt = set()
+    for atom in cur.get_unpacked_list():
+        for res in search.search(atom.get_coord(), radius, "R"):
+            nxt.add(res)
+    for res in nxt:
+        if res not in seen:
+            center |= merge_centers(res, search, seen, radius)
+    return center
+
+
+def get_center_residues(model, center_residues, merge_cutoff=4.0):
+    found = set()
+    center_atoms = []
+    for res in model.get_residues():
+        if res.get_resname() in center_residues:
+            found.add(res)
+            center_atoms.extend(res.get_unpacked_list())
+    if not len(center_atoms):
+        raise ValueError("No matching cluster centers found")
+    
+    search = NeighborSearch(center_atoms)
+    seen = set()
+    centers = []
+    for res in found:
+        if res not in seen:
+            centers.append(merge_centers(res, search, seen, merge_cutoff))
+    for c in centers:
+        for r in c:
+            print(r.get_full_id())
+        print()
+    return centers
+
+
 def box_outlier_thres(data, coeff=1.5):
     """
     Compute the threshold for the boxplot outlier detection method
@@ -267,18 +303,22 @@ def get_next_neighbors(
     spheres: list of sets
         Sets of residues separated by spheres
     """
-    seen = {start}
-    spheres = [{start}]
+    seen = start.copy()
+    spheres = [start]
     lig_adds = [set()]
     for i in range(0, sphere_count):
         # get candidate atoms in the new sphere
         nxt = set()
         lig_add = set()
         if i == 0 and first_sphere_radius > 0:
-            is_metal_like = (len(start.get_unpacked_list()) == 1)
-            search = NeighborSearch([atom for atom in start.get_parent().get_parent().get_atoms() if atom.element != "H" and atom not in start])
+            start_atoms = []
+            for res in start:
+                start_atoms.extend(res.get_unpacked_list())
+
+            is_metal_like = (len(start_atoms) == start)
+            search = NeighborSearch([atom for atom in start_atoms[0].get_parent().get_parent().get_parent().get_atoms() if atom.element != "H" and atom not in start_atoms])
             first_sphere = []
-            for center in start.get_unpacked_list():
+            for center in start_atoms:
                 first_sphere += search.search(center=center.get_coord(), radius=first_sphere_radius, level="A")
             for atom in first_sphere:
                 if atom.get_parent() not in seen:
@@ -335,14 +375,16 @@ def get_next_neighbors(
         spheres.append(nxt)
         lig_adds.append(lig_add)
 
-    res_id = start.get_full_id()
-    chain_name = res_id[2]
-    metal_index = str(res_id[3][1])
-    metal_id = chain_name + metal_index
+    metal_id = []
+    for res in start:
+        res_id = res.get_full_id()
+        chain_name = res_id[2]
+        metal_index = str(res_id[3][1])
+        metal_id.append(chain_name + metal_index)
     for i in range(len(spheres)):
         spheres[i] = spheres[i] | lig_adds[i]
     
-    return metal_id, seen, spheres
+    return "_".join(sorted(metal_id)), seen, spheres
 
 
 def scale_hydrogen(a, b, scale):
@@ -393,20 +435,12 @@ def build_hydrogen(chain, parent, template, atom):
     else:
         pos = scale_hydrogen(parent["C"], template["N"], 1.09 / 1.32)
 
-    res_id = parent.id
-    if not chain.has_id(res_id):
-        res = Residue(res_id, parent.get_resname(), " ")
-        res.add(Atom("H1", pos, 0, 1, " ", "H1", None, "H"))
-        chain.add(res)
-    else:
-        if "H1" not in chain[res_id]:
-            chain[res_id].add(Atom("H1", pos, 0, 1, " ", "H1", None, "H"))
-        elif "H2" not in chain[res_id]:
-            chain[res_id].add(Atom("H2", pos, 0, 1, " ", "H2", None, "H"))
-        else:
-            chain[res_id].add(Atom("H3", pos, 0, 1, " ", "H3", None, "H"))
-            
-    return chain[res_id]
+    for name in ["H1", "H2", "H3"]:
+        if name not in parent:
+            break
+    atom = Atom(name, pos, 0, 1, " ", name, None, "H")
+    parent.add(atom)
+    return atom
 
 
 def build_heavy(chain, parent, template, atom):
@@ -655,6 +689,7 @@ def extract_clusters(
     out,
     center_residues,
     sphere_count=2,
+    merge_cutoff=4.0,
     ligands=[],
     capping=0,
     charge=False,
@@ -699,38 +734,41 @@ def extract_clusters(
     model = structure[0]
     neighbors = voronoi(model, center_residues, ligands, smooth_method, **smooth_params)
 
+    centers = get_center_residues(model, center_residues, merge_cutoff)
+
     aa_charge = {}
     res_count = {}
     cluster_paths = []
-    for res in model.get_residues():
-        if res.get_resname() in center_residues:
-            metal_id, residues, spheres = get_next_neighbors(
-                res, neighbors, sphere_count, ligands, first_sphere_radius, smooth_method, **smooth_params
-            )
-            cluster_path = f"{out}/{metal_id}"
-            cluster_paths.append(cluster_path)
-            os.makedirs(cluster_path, exist_ok=True)
+    for c in centers:
+        metal_id, residues, spheres = get_next_neighbors(
+            c, neighbors, sphere_count, ligands, first_sphere_radius, smooth_method, **smooth_params
+        )
+        cluster_path = f"{out}/{metal_id}"
+        cluster_paths.append(cluster_path)
+        os.makedirs(cluster_path, exist_ok=True)
 
-            if charge:
-                aa_charge[metal_id] = compute_charge(spheres, structure, ligand_charge)
-            if count:
-                res_count[metal_id] = count_residues(spheres)
-            if capping:
-                cap_residues = cap_chains(model, residues, capping)
+        if charge:
+            aa_charge[metal_id] = compute_charge(spheres, structure, ligand_charge)
+        if count:
+            res_count[metal_id] = count_residues(spheres)
+        if capping:
+            cap_residues = cap_chains(model, residues, capping)
+            if capping == 2:
                 spheres[-1] |= cap_residues
 
-            sphere_paths = []
-            for i in range(sphere_count + 1):
-                if spheres[i]:
-                    sphere_path = f"{cluster_path}/{i}.pdb"
-                    sphere_paths.append(sphere_path)
-                    write_pdb(io, spheres[i], sphere_path)
-            # if capping:
-            #     for cap in cap_residues:
-            #         cap.get_parent().detach_child(cap.get_id())
-            if xyz:
-                struct_to_file.to_xyz(f"{cluster_path}/{metal_id}.xyz", *sphere_paths)
-                struct_to_file.combine_pdbs(f"{cluster_path}/{metal_id}.pdb", center_residues, *sphere_paths, hetero_pdb=hetero_pdb)
+        sphere_paths = []
+        for i in range(sphere_count + 1):
+            if spheres[i]:
+                sphere_path = f"{cluster_path}/{i}.pdb"
+                sphere_paths.append(sphere_path)
+                write_pdb(io, spheres[i], sphere_path)
+        if capping:
+            for cap in cap_residues:
+                cap.get_parent().detach_child(cap.get_id())
+        if xyz:
+            struct_to_file.to_xyz(f"{cluster_path}/{metal_id}.xyz", *sphere_paths)
+            struct_to_file.combine_pdbs(f"{cluster_path}/{metal_id}.pdb", center_residues, *sphere_paths, hetero_pdb=hetero_pdb)
+
     if charge:
         with open(f"{out}/charge.csv", "w") as f:
             f.write(f"Name,{','.join(str(x + 1) for x in range(sphere_count))}\n")

--- a/qp/manager/job_manager.py
+++ b/qp/manager/job_manager.py
@@ -116,7 +116,7 @@ def get_charge(structure_dir=None):
             # Parse charge.csv section 2
             elif section == 2:
                 ligand, value = line.split(',')
-                res_name, res_id_full = ligand.split('_')
+                res_name, res_id_full = ligand.split()[0].split('_')
                 chain = res_id_full[0]
                 res_id = int(res_id_full[1:])
                 for i in range(num_sphere + 1):

--- a/qp/structure/add_hydrogens.py
+++ b/qp/structure/add_hydrogens.py
@@ -124,7 +124,6 @@ def repair_ligands(path, orig):
     for res in prot_structure[0].get_residues():
         if res.get_resname() == "MOL":
             resid = res.get_id()
-            print(res.get_full_id())
             chain = res.get_parent()
             chain.detach_child(resid)
 
@@ -137,10 +136,8 @@ def repair_ligands(path, orig):
                     if r.get_id() not in chain:
                         chain.add(r)
                         missing.append(r)
-                        print(r.get_full_id())
                     else:
                         break
-            print()
 
             for r in missing:
                 for a in r.get_unpacked_list():

--- a/qp/structure/add_hydrogens.py
+++ b/qp/structure/add_hydrogens.py
@@ -116,6 +116,53 @@ def download(job, out, key="protein"):
         f.write(protoss.text)
 
 
+def repair_ligands(path, orig):
+    parser = PDBParser(QUIET=True)
+    prot_structure = parser.get_structure("Prot", path)
+    orig_structure = parser.get_structure("Orig", orig)
+
+    for res in prot_structure[0].get_residues():
+        if res.get_resname() == "MOL":
+            resid = res.get_id()
+            print(res.get_full_id())
+            chain = res.get_parent()
+            chain.detach_child(resid)
+
+            missing = []
+            found = False
+            for r in orig_structure[0][chain.get_id()].get_residues():
+                if r.get_id()[1] == resid[1]:
+                    found = True
+                if found:
+                    if r.get_id() not in chain:
+                        chain.add(r)
+                        missing.append(r)
+                        print(r.get_full_id())
+                    else:
+                        break
+            print()
+
+            for r in missing:
+                for a in r.get_unpacked_list():
+                    if a.element == "H":
+                        r.detach_child(atom.get_id())
+            
+            for atom in res.get_unpacked_list():
+                if atom.element != "H":
+                    continue
+                closest = None
+                for r in missing:
+                    for a in r.get_unpacked_list():
+                        if closest is None or atom - a < dist:
+                            closest = r
+                            dist = atom - a
+                closest.add(atom)
+
+    io = PDBIO()
+    io.set_structure(prot_structure)
+    io.save(path)
+
+
 def flip_coordinated_HIS(points, res):
     """
     Flip the imidazole ring of HIS if it can be coordinated with the metal
@@ -350,7 +397,7 @@ def compute_charge(path_ligand, path_pdb):
         n_atom = 0
         for line in l:
             if "V2000" in line:
-                n_atom = int(line.split()[0])
+                n_atom = int(line.split()[0][:3])
             if line.startswith("M  RGP"):
                 # R# atom is found in the addition between CSO and TAN
                 # It's not a real atom and recorded in the RGP entry

--- a/qp/structure/add_hydrogens.py
+++ b/qp/structure/add_hydrogens.py
@@ -321,7 +321,10 @@ def adjust_activesites(path, metals):
     points = []
     for res in structure[0].get_residues():
         if res.get_resname() in metals:
-            points.append(res.get_unpacked_list()[0])
+            atoms = res.get_unpacked_list()
+            if len(atoms) > 1:
+                continue # skip if not metal-like
+            points.append(atoms[0])
 
     for res in structure[0].get_residues():
         if res.get_resname() == "HIS":


### PR DESCRIPTION
Automatically merge residues based on distance cutoff
- `merge_distance_cutoff` parameter in config file
- Applicable to bimetallic sites and polymers

Additional notes:
- Ligands tagged `MOL` by Protoss are renamed to their original residues. A single `MOL` residue may have duplicate atoms, which leads to PDB parsing issues.
- Fix bug where capping hydrogens are left behind when processing multiple clusters