### PR TITLE
Included HETATMs in file PDB

### DIFF
--- a/qp/structure/struct_to_file.py
+++ b/qp/structure/struct_to_file.py
@@ -45,8 +45,6 @@ def combine_pdbs(out_path, metals, *input_paths, hetero_pdb=False):
         for path in input_paths:
             with open(path) as infile:
                 for line in infile:
-                    if not hetero_pdb and line.startswith("HETATM") and all(metal not in line for metal in metals):
-                        continue
                     if line.startswith("END"):
                         continue
                     outfile.write(line)


### PR DESCRIPTION
In addition to the final XYZ cluster models that get generated, there is also a final PDB cluster model that gets generated. Previously this cluster model excluded HETATMs. This was used in a previous project but is not longer needed. The final cluster model PDB will now contain all atoms that are in the cluster model.