### PR TITLE
Automatic resubmission to Protoss server

### DIFF
--- a/qp/_version.py
+++ b/qp/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0+218.g6c2eab3.dirty"
+__version__ = "1.0.0+238.g59cf489.dirty"


### PR DESCRIPTION
It seems that recently the Protoss server has become less stable. In my most recent querying of the server, it would often fail on the upload, download, or submit steps. This meant that qp was dying after every 10-20 cluster models. To fix this, I updated the add_hydrogens module so that it would automatically re-query Protoss if something went wrong.