### PR TITLE
Update oxo generator

### DIFF
--- a/qp/structure/convert_to_oxo.py
+++ b/qp/structure/convert_to_oxo.py
@@ -102,7 +102,7 @@ def place_oxo_manually(atoms, iron):
         clash_threshold = 1.8
         clash = False
         for atom in atoms:
-            if atom['serial'] != iron['serial']:  # Exclude the iron itself from the clash detection
+            if atom['serial'] != iron['serial'] and not (atom['resName'] == 'AKG' and atom['name'] in ['C1', 'O1', 'O2']):  # Exclude specific AKG atoms from clash detection
                 distance = np.linalg.norm(np.array([atom['x'], atom['y'], atom['z']]) - oxo_coord)
                 if distance < clash_threshold:
                     clash = True


### PR DESCRIPTION
I updated the `convert_to_oxo.py` module so that when the coordination site of the oxo is determined the atoms of AKG that are released as CO2 are not considered in determining clashes. This was key to fixing 6ALM.