### PR TITLE
Added M3L has a positive nonstandard

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ protoss: true                          # Assign protonation states
 coordination: true                     # Generate clusters
 skip: all                              # Skip 'modeller', 'protoss', or 'all' jobs if they already exist
 optimize_select_residues: 1            # Modeller to model no (0), missing (1), or all (2) residues
-convert_to_oxo: false                   # Used to convert A-KG NHIEs to Succinate-Oxo NHIEs, usually False
+convert_to_oxo: true                   # Used to convert A-KG NHIEs to Succinate-Oxo NHIEs, usually False
 
 # Cluster model parameters
 max_atom_count: 750            

--- a/qp/cluster/coordination_spheres.py
+++ b/qp/cluster/coordination_spheres.py
@@ -687,7 +687,8 @@ def compute_charge(spheres, structure, ligand_charge):
         "ARG": ["HE", "HH11", "HH12", "HH21", "HH22"],
         "LYS": ["HZ1", "HZ2", "HZ3"],
         "HIS": ["HD1", "HD2", "HE1", "HE2"],
-        "MLZ": []
+        "MLZ": [],
+        "M3Z": []
     }
     neg = {
         "ASP": ["HD2", "HOD1", "HOD2"],


### PR DESCRIPTION
We discovered a new positively charged non standard residue called M3L that appeared in PDB 2P5B. We added it to the code such that its charge will be properly counted.