### PR TITLE
Made center column optional

### DIFF
--- a/qp/checks/fetch_pdb.py
+++ b/qp/checks/fetch_pdb.py
@@ -95,7 +95,13 @@ def get_centers(input_path):
                 input_csv = pdb_id
                 with open(input_csv, "r") as csvfile:
                     reader = csv.DictReader(csvfile)
+                    # Check if 'center' column exists
+                    if 'center' not in reader.fieldnames:
+                        print(f"> WARNING: The 'center' option is not being used in {input_csv}. Returning empty list.")
+                        return []
+                    # If the 'center' column exists, proceed to collect centers
                     for row in reader:
-                        center = row['center']
-                        centers.append(center)
+                        center = row.get('center', None)
+                        if center:
+                            centers.append(center)
     return centers


### PR DESCRIPTION
I updated the way the input csv is parsed such that the `center` column is now optional. If the `center` column is not included in the input csv then it is the same as if the column was empty and will default to whatever is in the yaml.