### PR TITLE
Improve user notification of resolved clashes

### DIFF
--- a/qp/cli.py
+++ b/qp/cli.py
@@ -205,7 +205,9 @@ def run(config):
                 AA = missing.define_residues()
                 residues_with_clashes = parse_log(protoss_log_file, protoss_pdb, AA)
                 if residues_with_clashes:
-                    print(f"> WARNING: Protoss has deleted {len(residues_with_clashes)} residues due to clashes, trying to fix them with Modeller")
+                    print(f"> WARNING: Protoss removed {len(residues_with_clashes)} residues due to clashes")
+                    clash_details = ", ".join([f"{res_name}{res_id} in chain {chain}" for res_id, _, _, chain, res_name in sorted(list(residues_with_clashes))])
+                    print(f"> WARNING: Remodeling {clash_details} with Modeller.")
                 else:
                     break # Don't loop again as no clashes were detected
 

--- a/qp/protonate/parse_output.py
+++ b/qp/protonate/parse_output.py
@@ -35,7 +35,7 @@ def parse_log(log_path, pdb_path, AA):
                 res_id = int(atom_line[22:26].strip())
                 one_letter_code = AA.get(res_name, 'X')  # Use 'X' for unknown residues
                 chain_index = chain_order.get(chain, -1)
-                residues_with_clashes.add((res_id, one_letter_code, chain_index, chain))
+                residues_with_clashes.add((res_id, one_letter_code, chain_index, chain, res_name))
 
     return residues_with_clashes
 

--- a/qp/structure/missing.py
+++ b/qp/structure/missing.py
@@ -454,7 +454,7 @@ def delete_clashes(pdb_path, residues_with_clashes):
         lines = file.readlines()
 
     # Create a set for quick lookup of residues to delete
-    residues_to_delete = {(chain, res_id) for res_id, _, _, chain in residues_with_clashes}
+    residues_to_delete = {(chain, res_id) for res_id, _, _, chain, _ in residues_with_clashes}
 
     # Write the new PDB file, excluding the residues to delete
     with open(pdb_path, "w") as file:


### PR DESCRIPTION
During the iterative remodeling of clashes using Protoss and Modeller, the specific residues that are being remodeled are now printed to the command line.