### PR TITLE
Switch to Hirshfeld as default charge scheme

### DIFF
--- a/qp/analyze/multiwfn.py
+++ b/qp/analyze/multiwfn.py
@@ -54,7 +54,7 @@ def iterate_qm_output(pdb_all, method, base_output_dir, multiwfn_path, settings_
                 # Copy the atmrad dir and settings.ini into the current working directory
                 atmrad_dest_path = os.path.join(scr_dir_path, 'atmrad/')
                 if not os.path.exists(atmrad_dest_path):
-                    shutil.copytree(atmrad_path, atmrad_dest_path)
+                    shutil.copytree(atmrad_path, atmrad_dest_path, dirs_exist_ok=True)
 
                 settings_ini_dest_path = os.path.join(scr_dir_path, 'settings.ini')
                 shutil.copy(settings_ini_path, settings_ini_dest_path)
@@ -71,8 +71,11 @@ def iterate_qm_output(pdb_all, method, base_output_dir, multiwfn_path, settings_
                     if molden_files:
                         molden_file = os.path.basename(molden_files[0])
                         task_function(scr_dir_path, molden_file, multiwfn_path, charge_scheme)
-                        shutil.rmtree('atmrad/')  # Delete the atmrad directory when done
-                        os.remove('settings.ini')  # Delete the settings.ini file when done
+                        shutil.rmtree('atmrad/', ignore_errors=True)
+                        try:
+                            os.remove('settings.ini')
+                        except FileNotFoundError:
+                            pass
                     else:
                         print(f"> WARNING: No molden file in {scr_dir_path}")
                     os.chdir(original_dir)

--- a/qp/cli.py
+++ b/qp/cli.py
@@ -344,7 +344,7 @@ def analyze(config):
     calc_charge_schemes = config_data.get('calc_charge_schemes', False)
     calc_dipole = config_data.get('calc_dipole', False)
     multiwfn_path = config_data.get('multiwfn_path', 'Multiwfn')
-    charge_scheme = config_data.get('charge_scheme', 'Hirshfeld-I')
+    charge_scheme = config_data.get('charge_scheme', 'Hirshfeld')
     input = config_data.get('input', [])
     output = config_data.get('output_dir', '')
     center_yaml_residues = config_data.get('center_residues', [])


### PR DESCRIPTION
For large systems Hirshfeld-I will run into a memory issue. Therefore, we switch to Hirshfeld as the default partial charge scheme.