### PR TITLE
Fix ECP in molden

### DIFF
--- a/qp/analyze/checkup.py
+++ b/qp/analyze/checkup.py
@@ -53,22 +53,27 @@ def check_submit_record(submit_record_path, delete_queued):
     with open(submit_record_path, 'r') as f:
         content = f.read()
 
-        author = extract_author(content)
-        queue_time = "Queue Time:" in content
-        run_start_time = "Run Start Time:" in content
-        run_end_time = "Run End Time:" in content
+    author = extract_author(content)
+    queue_time     = "Queue Time:" in content
+    run_start_time = "Run Start Time:" in content
+    run_end_time   = "Run End Time:" in content
 
-        # if queue_time and not run_start_time:
-        if run_start_time and not run_end_time:
-            if delete_queued:
-                print(f"Deleting queued job record: {submit_record_path}")
-                os.remove(submit_record_path)
-            return "queue", author
-        elif run_start_time and not run_end_time:
-            return "running", author
-        elif run_end_time:
-            return "done", author
-        
+    # Queued but never started
+    if queue_time and not run_start_time:
+        if delete_queued:
+            print(f"Deleting queued job record: {submit_record_path}")
+            os.remove(submit_record_path)
+        return "queue", author
+
+    # Started but not finished
+    if run_start_time and not run_end_time:
+        return "running", author
+
+    # Finished
+    if run_end_time:
+        return "done", author
+
+    # Fallback (record present but missing expected markers)
     return "backlog", author
 
 

--- a/qp/analyze/molden.py
+++ b/qp/analyze/molden.py
@@ -1,4 +1,56 @@
 import numpy as np
+import os
+
+VALENCE_ELECTRONS = {
+    'CA': 2, 'CD': 12, 'CO': 9, 'CU': 11, 'FE': 8, 'K': 1,
+    'MN': 7, 'NI': 10, 'PB': 14, 'V': 5, 'ZN': 12
+}
+
+def correct_ecp_charges_inplace(molden_file):
+    """
+    Corrects the nuclear charge in a Molden file for elements with ECPs,
+    overwriting the original file.
+    """
+    try:
+        with open(molden_file, 'r') as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        print(f"> ERROR: Molden file not found at {molden_file}")
+        return
+
+    modified_lines = []
+    in_atoms_section = False
+    was_modified = False
+    for line in lines:
+        if line.strip() == "[Atoms] Angs":
+            in_atoms_section = True
+            modified_lines.append(line)
+            continue
+        elif in_atoms_section and line.strip().startswith("["):
+            in_atoms_section = False
+        
+        if in_atoms_section:
+            parts = line.strip().split()
+            if len(parts) >= 6:
+                element_symbol = parts[0].upper()
+                # Check if the element needs correction and if it hasn't been corrected already
+                if element_symbol in VALENCE_ELECTRONS and parts[2] != str(VALENCE_ELECTRONS[element_symbol]):
+                    parts[2] = str(VALENCE_ELECTRONS[element_symbol])
+                    line_to_write = '     '.join(parts) + '\n'
+                    modified_lines.append(line_to_write)
+                    was_modified = True
+                else:
+                    modified_lines.append(line)
+            else:
+                modified_lines.append(line)
+        else:
+            modified_lines.append(line)
+    
+    if was_modified:
+        with open(molden_file, 'w') as f:
+            f.writelines(modified_lines)
+        print(f"> Overwrote {os.path.basename(molden_file)} with ECP-corrected nuclear charges.")
+
 
 def translate_to_origin(coordinates, center_of_mass):
     """Translates the molecule so the center of mass is at the origin."""


### PR DESCRIPTION
If an ECP is used with the basis set in Terachem then the valence will be incorrect in the molden. Updated the analyze subpackage to check for incorrect valencies in common metals. More may need to be added for special cases.